### PR TITLE
More robust xcodeproj finding

### DIFF
--- a/scripts/prepare_command.rb
+++ b/scripts/prepare_command.rb
@@ -3,7 +3,7 @@ require 'cocoapods'
 require 'find'
 
 BUILD_PHASE_NAME = "Label Optimizely Views"
-SHELL_SCRIPT = "python \"$SRCROOT/Pods/Optimizely-iOS-SDK/scripts/OptimizelyPrepareNibs.py\""
+SHELL_SCRIPT = "python \"$PODS_ROOT/Optimizely-iOS-SDK/scripts/OptimizelyPrepareNibs.py\""
 
 # Find main project file by looking in the Podfile declaration
 xcodeproj_path = begin


### PR DESCRIPTION
Make the prepare command use the Podfile to find the `xcodeproj` instead o expecting it to be next to the Podfile.

Some projects don't keep their `xcodeproj` next to their Podfile, and if they don't, they'll specify a path for it in their Podfile and we can use that.

Also, use `PODS_ROOT` instead of `SRCROOT` to link to the python script. The `Pods` directory is not guaranteed to be in the `SRCROOT`
