### PR TITLE
1.0.75

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Optimizely-iOS-SDK CHANGELOG
 
+## 1.0.75
+January 14, 2015
+
+**Optimizely versions 0.8 (and up) require iOS 7 or higher.**
+
+- Added a NSNotification for when we get new experiment data
+- Fixed a bug with downloading our JSON config
+
 ## 1.0.74
 January 8, 2015
 

--- a/Optimizely-iOS-SDK.podspec
+++ b/Optimizely-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Optimizely-iOS-SDK"
-  s.version          = "1.0.74"
+  s.version          = "1.0.75"
   s.summary          = "Optimizely is the #1 optimization platform in the world."
   s.homepage         = "http://www.optimizely.com"
   s.license          = { :type => 'Commercial', :text => 'See http://developers.optimizely.com/ios/terms' }  
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 
-  s.source           = { :git => "https://github.com/optimizely/Optimizely-iOS-SDK.git", :tag => "1.0.74" }
+  s.source           = { :git => "https://github.com/optimizely/Optimizely-iOS-SDK.git", :tag => "1.0.75" }
 
   s.frameworks = 'AudioToolbox', 'CFNetwork', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
   s.libraries = 'icucore', 'sqlite3'

--- a/Optimizely.framework/Versions/A/Headers/Optimizely.h
+++ b/Optimizely.framework/Versions/A/Headers/Optimizely.h
@@ -348,6 +348,9 @@ typedef void (^OptimizelySuccessBlock)(BOOL success, NSError *error);
  * that once a view becomes visible, a variable is read, or a code block is executed,
  * its value/appearance will not change for the duration of the app run
  * (applicationDidFinishLaunching:withOptions: is called).
+ *
+ * If a foregrounding event results in new experiment data, Optimizely will trigger an
+ * NSNotification with the key "OptimizelyNewDataFileLoaded."
  */
 @property (assign) BOOL shouldReloadExperimentsOnForegrounding;
 


### PR DESCRIPTION
## 1.0.75
January 14, 2015

**Optimizely versions 0.8 (and up) require iOS 7 or higher.**

- Added a NSNotification for when we get new experiment data
- Fixed a bug with downloading our JSON config