### PR TITLE
1.0.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Optimizely-iOS-SDK CHANGELOG
 
+## 1.0.76
+February 11, 2015
+
+**Optimizely versions 0.8 (and up) require iOS 7 or higher.**
+
+- Urgent fix for an issue with counting visitors in experiments. For more information please visit our [Optiverse page](https://community.optimizely.com/t5/Mobile-Apps/Known-Issue-Mobile-results-are-over-counting-visitors/m-p/9096)
+- Added manual activation through refreshExperimentData
+- Added notifications for when an experiment is viewed and when we load new experiment data
+- Other minor bug fixes
+
 ## 1.0.75
 January 14, 2015
 

--- a/Optimizely-iOS-SDK.podspec
+++ b/Optimizely-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Optimizely-iOS-SDK"
-  s.version          = "1.0.75"
+  s.version          = "1.0.76"
   s.summary          = "Optimizely is the #1 optimization platform in the world."
   s.homepage         = "http://www.optimizely.com"
   s.license          = { :type => 'Commercial', :text => 'See http://developers.optimizely.com/ios/terms' }  
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 
-  s.source           = { :git => "https://github.com/optimizely/Optimizely-iOS-SDK.git", :tag => "1.0.75" }
+  s.source           = { :git => "https://github.com/optimizely/Optimizely-iOS-SDK.git", :tag => "1.0.76" }
 
   s.frameworks = 'AudioToolbox', 'CFNetwork', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
   s.libraries = 'icucore', 'sqlite3'


### PR DESCRIPTION
## 1.0.76
February 11, 2015

**Optimizely versions 0.8 (and up) require iOS 7 or higher.**

- Urgent fix for an issue with counting visitors in experiments. For more information please visit our [Optiverse page](https://community.optimizely.com/t5/Mobile-Apps/Known-Issue-Mobile-results-are-over-counting-visitors/m-p/9096)
- Added manual activation through refreshExperimentData
- Added notifications for when an experiment is viewed and when we load new experiment data
- Other minor bug fixes