### PR TITLE
1.0.78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Optimizely-iOS-SDK CHANGELOG
 
+## 1.0.78
+February 26, 2015
+
+**Optimizely versions 0.8 (and up) require iOS 7 or higher.**
+
+- Goals are now triggered based on whether or not the user has ever viewed a given experiment in their lifetime
+- Added notification for when a goal is triggered
+- Added allExperiments and viewedExperiments which return an array of OptimizelyExperimentData objects that store data pertaining to the current state of each experiment
+- Updated our analytics integrations to utilize viewedExperiments
+- Added the ability for the developer to disable the Optimizely Gesture
+- Removed session and retention goals
+- activeExperiments deprecated, please use allExperiments or viewedExperiments
+
 ## 1.0.76
 February 11, 2015
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Optimizely-iOS-SDK CHANGELOG
 
+## 1.0.76
+February 11, 2015
+
+**Optimizely versions 0.8 (and up) require iOS 7 or higher.**
+
+- Urgent fix for an issue with counting visitors in experiments. For more information please visit our [Optiverse page](https://community.optimizely.com/t5/Mobile-Apps/Known-Issue-Mobile-results-are-over-counting-visitors/m-p/9096)
+- Added manual activation through refreshExperimentData
+- Added notifications for when an experiment is viewed and when we load new experiment data
+- Other minor bug fixes
+
 ## 1.0.75
 January 14, 2015
 

--- a/Optimizely-iOS-SDK.podspec
+++ b/Optimizely-iOS-SDK.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name             = "Optimizely-iOS-SDK"
-  s.version          = "1.0.76"
+  s.version          = "1.0.78"
   s.summary          = "Optimizely is the #1 optimization platform in the world."
   s.homepage         = "http://www.optimizely.com"
-  s.license          = { :type => 'Commercial', :text => 'See http://developers.optimizely.com/ios/terms' }  
+  s.license          = { :type => 'Commercial', :text => 'See http://developers.optimizely.com/ios/terms' }
   s.author           = { "Optimizely" => "support@optimizely.com" }
   s.social_media_url = 'https://twitter.com/optimizely'
 
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 
-  s.source           = { :git => "https://github.com/optimizely/Optimizely-iOS-SDK.git", :tag => "1.0.76" }
+  s.source           = { :git => "https://github.com/optimizely/Optimizely-iOS-SDK.git", :tag => "1.0.78" }
 
   s.frameworks = 'AudioToolbox', 'CFNetwork', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
   s.libraries = 'icucore', 'sqlite3'

--- a/Optimizely-iOS-SDK.podspec
+++ b/Optimizely-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Optimizely-iOS-SDK"
-  s.version          = "1.0.75"
+  s.version          = "1.0.76"
   s.summary          = "Optimizely is the #1 optimization platform in the world."
   s.homepage         = "http://www.optimizely.com"
   s.license          = { :type => 'Commercial', :text => 'See http://developers.optimizely.com/ios/terms' }  
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 
-  s.source           = { :git => "https://github.com/optimizely/Optimizely-iOS-SDK.git", :tag => "1.0.75" }
+  s.source           = { :git => "https://github.com/optimizely/Optimizely-iOS-SDK.git", :tag => "1.0.76" }
 
   s.frameworks = 'AudioToolbox', 'CFNetwork', 'Foundation', 'Security', 'SystemConfiguration', 'UIKit'
   s.libraries = 'icucore', 'sqlite3'

--- a/Optimizely.framework/Versions/A/Headers/OptimizelyCodeBlocksKey.h
+++ b/Optimizely.framework/Versions/A/Headers/OptimizelyCodeBlocksKey.h
@@ -1,4 +1,9 @@
-
+//
+//  OptimizelyCodeBlocksKey.h
+//  Optimizely
+//
+//  Created by Optimizely Engineering on 2/19/15.
+//  Copyright (c) 2015 Optimizely Engineering. All rights reserved.
 
 /** This class defines a key that can be used to define an Optimizely code blocks experiment.
  *

--- a/Optimizely.framework/Versions/A/Headers/OptimizelyExperimentData.h
+++ b/Optimizely.framework/Versions/A/Headers/OptimizelyExperimentData.h
@@ -1,0 +1,68 @@
+//
+//  OptimizelyExperimentData.h
+//  Optimizely
+//
+//  Created by Optimizely Engineering on 2/19/15.
+//  Copyright (c) 2015 Optimizely Engineering. All rights reserved.
+//
+
+/**
+ *  Type describing the current state of the experiment
+ */
+typedef NS_ENUM (NSUInteger, OptimizelyExperimentDataState) {
+    /** Experiment is not running on the Optimizely dashboard. Try starting the experiment on https://www.optimizely.com */
+    OptimizelyExperimentDataStateDisabled,
+    /** Experiment is running */
+    OptimizelyExperimentDataStateRunning,
+    /** Experiment has been deactivated
+     * This can happen if
+     * (a) not all of its assets are downloaded by the time our block time runs out, or
+     * (b) another experiment has already been activated that makes a conflicting change
+     * (c) targeting criteria for this experiment has not been met
+     */
+    OptimizelyExperimentDataStateDeactivated
+};
+
+/**
+ *  This class represents the data for the current state of your Optimizely experiment object.
+ *  You can choose to access various properties to figure out the current experiment state
+ *  within Optimizely.
+ */
+@interface OptimizelyExperimentData : NSObject
+
+/** Property that counts the number of times the user has seen this experiment */
+@property (nonatomic, readonly) NSUInteger visitedCount;
+
+/** Property that computes whether or not the user has seen this experiment in their lifetime */
+@property (nonatomic, readonly) BOOL visitedEver;
+
+/** Property that tells you whether or not the user has seen this experiment this session */
+@property (nonatomic, readonly) BOOL visitedThisSession;
+
+/** Property that tells you whether or not your user has met targeting conditions */
+@property (nonatomic, readonly) BOOL targetingMet;
+
+/** Property that tells you whether or not your was locked out of activation, because another experiment
+ *  was making a conflicting change or your assets did not finish downloading in time
+ */
+@property (nonatomic, readonly) BOOL locked;
+
+/** Property that tells you the experiment Id */
+@property (nonatomic, readonly, strong) NSString *experimentId;
+
+/** Property that tells you the experiment Name */
+@property (nonatomic, readonly, strong) NSString *experimentName;
+
+/** Property that tells you the variation Id (can be nil if not bucketed) */
+@property (nonatomic, readonly, strong) NSString *variationId;
+
+/** Property that tells you the variation Name (can be nil if not bucketed) */
+@property (nonatomic, readonly, strong) NSString *variationName;
+
+/** Property that tells you the targeting conditions currently associated with this experiment */
+@property (nonatomic, readonly, strong) NSString *targetingConditions;
+
+/** Property that tells you the state of the experiment */
+@property (readonly) OptimizelyExperimentDataState state;
+
+@end


### PR DESCRIPTION
## 1.0.78
February 26, 2015

**Optimizely versions 0.8 (and up) require iOS 7 or higher.**

- Goals are now triggered based on whether or not the user has ever viewed a given experiment in their lifetime
- Added notification for when a goal is triggered
- Added allExperiments and viewedExperiments which return an array of OptimizelyExperimentData objects that store data pertaining to the current state of each experiment
- Updated our analytics integrations to utilize viewedExperiments
- Added the ability for the developer to disable the Optimizely Gesture
- Removed session and retention goals
- activeExperiments deprecated, please use allExperiments or viewedExperiments